### PR TITLE
Oyj profile equipment dto

### DIFF
--- a/backend/bin/main/application.yml
+++ b/backend/bin/main/application.yml
@@ -1,9 +1,12 @@
 spring:
+  profiles:
+    active: local
   datasource:
     url: jdbc:mysql://localhost:3306/loacompass
     username: bit1234
     password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
+
 
 mybatis:
   mapper-locations: classpath:mapper/**/*.xml

--- a/backend/src/main/java/com/finalteam/loacompass/client/LostArkClient.java
+++ b/backend/src/main/java/com/finalteam/loacompass/client/LostArkClient.java
@@ -2,11 +2,15 @@ package com.finalteam.loacompass.client;
 
 import com.finalteam.loacompass.dto.ArmoryResponse;
 import com.finalteam.loacompass.dto.CharacterProfileDto;
+import com.finalteam.loacompass.dto.EquipmentDto;
+import com.finalteam.loacompass.util.TooltipParser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -24,5 +28,34 @@ public class LostArkClient {
            .block();
    return response.getArmoryProfile();
    }
+
+    private boolean isGear(String type) {
+        return List.of("무기", "투구", "상의", "하의", "장갑", "어깨").contains(type);
+    }
+
+    public List<EquipmentDto> getCharacterEquipment(String nickname) {
+        ArmoryResponse response = lostArkWebClient.get()
+                .uri("/armories/characters/{name}", nickname)
+                .retrieve()
+                .bodyToMono(ArmoryResponse.class)
+                .block();
+
+        List<EquipmentDto> equipmentList = response.getArmoryEquipment();
+
+        for (EquipmentDto dto : equipmentList) {
+            // 장비 유형 로그 확인용
+            log.info("==== [{}] {} ====", dto.getType(), dto.getName());
+
+            if (isGear(dto.getType())) {
+                TooltipParser.populateEquipmentDetails(dto); // 강화/초월/엘릭서 추출
+
+            } else {
+                log.info("※ [{}]은(는) 장비 외 항목이므로 파싱 생략", dto.getType());
+            }
+        }
+
+        return equipmentList;
+    }
+
 }
 

--- a/backend/src/main/java/com/finalteam/loacompass/client/LostArkClient.java
+++ b/backend/src/main/java/com/finalteam/loacompass/client/LostArkClient.java
@@ -6,9 +6,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 
@@ -16,13 +16,13 @@ public class LostArkClient {
 
     private final WebClient lostArkWebClient;
 
-    public CharacterProfileDto getCharacterProfile(String nickname) {
-        return lostArkWebClient.get()
-                .uri("/armories/characters/{name}", nickname)
-                .retrieve()
-                .bodyToMono(ArmoryResponse.class) // 전체 응답 구조 파싱
-                .block()
-                .getArmoryProfile(); // 그중 필요한 profile만 꺼냄
-    }
+   public CharacterProfileDto getCharacterProfile(String nickname) {
+   ArmoryResponse response = lostArkWebClient.get()
+           .uri("/armories/characters/{name}", nickname)
+           .retrieve()
+           .bodyToMono(ArmoryResponse.class)
+           .block();
+   return response.getArmoryProfile();
+   }
 }
 

--- a/backend/src/main/java/com/finalteam/loacompass/client/LostArkClient.java
+++ b/backend/src/main/java/com/finalteam/loacompass/client/LostArkClient.java
@@ -42,13 +42,14 @@ public class LostArkClient {
 
         List<EquipmentDto> equipmentList = response.getArmoryEquipment();
 
+        int totalTranscendence = 0;
+
         for (EquipmentDto dto : equipmentList) {
             // 장비 유형 로그 확인용
             log.info("==== [{}] {} ====", dto.getType(), dto.getName());
 
             if (isGear(dto.getType())) {
                 TooltipParser.populateEquipmentDetails(dto); // 강화/초월/엘릭서 추출
-
             } else {
                 log.info("※ [{}]은(는) 장비 외 항목이므로 파싱 생략", dto.getType());
             }
@@ -56,6 +57,7 @@ public class LostArkClient {
 
         return equipmentList;
     }
+
 
 }
 

--- a/backend/src/main/java/com/finalteam/loacompass/config/WebClientConfig.java
+++ b/backend/src/main/java/com/finalteam/loacompass/config/WebClientConfig.java
@@ -31,11 +31,4 @@ public class WebClientConfig {
                         .build())
                 .build();
     }
-
-    @PostConstruct
-    public void debug() {
-        System.out.println("🔍 WebClientConfig 확인:");
-        System.out.println("baseUrl = " + baseUrl);
-        System.out.println("apiKey = " + apiKey); // null 또는 빈 값이면 문제!
-    }
 }

--- a/backend/src/main/java/com/finalteam/loacompass/controller/CharacterController.java
+++ b/backend/src/main/java/com/finalteam/loacompass/controller/CharacterController.java
@@ -1,6 +1,7 @@
 package com.finalteam.loacompass.controller;
 
 import com.finalteam.loacompass.dto.CharacterProfileDto;
+import com.finalteam.loacompass.dto.CharacterSummaryDto;
 import com.finalteam.loacompass.service.CharacterService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,7 +16,7 @@ public class CharacterController {
     private final CharacterService characterService;
 
     @GetMapping("/{nickname}")
-    public CharacterProfileDto search(@PathVariable String nickname) {
+    public CharacterSummaryDto search(@PathVariable String nickname) {
         return characterService.getCharacter(nickname);
     }
 }

--- a/backend/src/main/java/com/finalteam/loacompass/dto/ArmoryResponse.java
+++ b/backend/src/main/java/com/finalteam/loacompass/dto/ArmoryResponse.java
@@ -13,6 +13,9 @@ public class ArmoryResponse {
     @JsonProperty("ArmoryProfile")
     private CharacterProfileDto armoryProfile;
 
+    @JsonProperty("ArmoryEquipment")
+    private List<EquipmentDto> armoryEquipment;
+
     // 필요 시 ArmoryEquipment 등 다른 필드도 추가 가능
 }
 

--- a/backend/src/main/java/com/finalteam/loacompass/dto/ArmoryResponse.java
+++ b/backend/src/main/java/com/finalteam/loacompass/dto/ArmoryResponse.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ArmoryResponse {

--- a/backend/src/main/java/com/finalteam/loacompass/dto/CharacterProfileDto.java
+++ b/backend/src/main/java/com/finalteam/loacompass/dto/CharacterProfileDto.java
@@ -4,25 +4,28 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
+import java.util.Map;
+
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
+
 public class CharacterProfileDto {
-
-    @JsonProperty("CharacterName")
     private String characterName;
-
-    @JsonProperty("CharacterClassName")
     private String characterClassName;
-
-    @JsonProperty("ItemAvgLevel")
-    private String itemAvgLevel;
-
-    @JsonProperty("ItemMaxLevel")
-    private String itemMaxLevel;
-
-    @JsonProperty("CharacterLevel")
     private int characterLevel;
-
-    @JsonProperty("ServerName")
+    private String itemAvgLevel;
+    private String itemMaxLevel;
     private String serverName;
+    private String characterImage;
+
+    private int expeditionLevel;
+    private String guildName;
+    private String guildMemberGrade;
+    private String title;
+    private String pvpGradeName;
+    private int townLevel;
+    private String townName;
+
+    private Map<String, Integer> combatStats;  // 치명, 특화 등
+    private Map<String, Integer> socialStats;  // 지성, 담력 등
 }

--- a/backend/src/main/java/com/finalteam/loacompass/dto/CharacterProfileDto.java
+++ b/backend/src/main/java/com/finalteam/loacompass/dto/CharacterProfileDto.java
@@ -8,24 +8,48 @@ import java.util.Map;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
-
 public class CharacterProfileDto {
+
+    @JsonProperty("CharacterName")
     private String characterName;
+
+    @JsonProperty("CharacterClassName")
     private String characterClassName;
+
+    @JsonProperty("CharacterLevel")
     private int characterLevel;
+
+    @JsonProperty("ItemAvgLevel")
     private String itemAvgLevel;
+
+    @JsonProperty("ItemMaxLevel")
     private String itemMaxLevel;
+
+    @JsonProperty("ServerName")
     private String serverName;
+
+    @JsonProperty("CharacterImage")
     private String characterImage;
 
+    @JsonProperty("ExpeditionLevel")
     private int expeditionLevel;
+
+    @JsonProperty("GuildName")
     private String guildName;
+
+    @JsonProperty("GuildMemberGrade")
     private String guildMemberGrade;
+
+    @JsonProperty("Title")
     private String title;
+
+    @JsonProperty("PvpGradeName")
     private String pvpGradeName;
+
+    @JsonProperty("TownLevel")
     private int townLevel;
+
+    @JsonProperty("TownName")
     private String townName;
 
-    private Map<String, Integer> combatStats;  // 치명, 특화 등
-    private Map<String, Integer> socialStats;  // 지성, 담력 등
 }

--- a/backend/src/main/java/com/finalteam/loacompass/dto/CharacterSummaryDto.java
+++ b/backend/src/main/java/com/finalteam/loacompass/dto/CharacterSummaryDto.java
@@ -1,0 +1,9 @@
+package com.finalteam.loacompass.dto;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class CharacterSummaryDto {
+    private CharacterProfileDto profile;
+}

--- a/backend/src/main/java/com/finalteam/loacompass/dto/CharacterSummaryDto.java
+++ b/backend/src/main/java/com/finalteam/loacompass/dto/CharacterSummaryDto.java
@@ -6,4 +6,5 @@ import java.util.List;
 @Data
 public class CharacterSummaryDto {
     private CharacterProfileDto profile;
+    private List<EquipmentDto> equipments;
 }

--- a/backend/src/main/java/com/finalteam/loacompass/dto/CharacterSummaryDto.java
+++ b/backend/src/main/java/com/finalteam/loacompass/dto/CharacterSummaryDto.java
@@ -7,4 +7,5 @@ import java.util.List;
 public class CharacterSummaryDto {
     private CharacterProfileDto profile;
     private List<EquipmentDto> equipments;
+    private int transcendenceTotal;  // 총 초월 수치
 }

--- a/backend/src/main/java/com/finalteam/loacompass/dto/EquipmentDto.java
+++ b/backend/src/main/java/com/finalteam/loacompass/dto/EquipmentDto.java
@@ -28,5 +28,10 @@ public class EquipmentDto {
     private Integer transcendenceLevel;      // 초월 단계
     private String elixirName;               // 엘릭서 이름
     private List<String> elixirEffects;      // 엘릭서 효과
+    private List<String> elixirOptions;  // 옵션 이름만 저장
+    private Integer quality;            // 품질
+    private Integer transcendencePoint;  // 장비별 초월 포인트
+
+
 
 }

--- a/backend/src/main/java/com/finalteam/loacompass/dto/EquipmentDto.java
+++ b/backend/src/main/java/com/finalteam/loacompass/dto/EquipmentDto.java
@@ -1,0 +1,32 @@
+package com.finalteam.loacompass.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+
+public class EquipmentDto {
+
+    @JsonProperty("Type")
+    private String type;
+
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("Icon")
+    private String icon;
+
+    @JsonProperty("Grade")
+    private String grade;
+
+    @JsonProperty("Tooltip")
+    private String tooltip;
+
+    private Integer refinementLevel;         // 강화 단계
+    private Integer transcendenceLevel;      // 초월 단계
+    private String elixirName;               // 엘릭서 이름
+    private List<String> elixirEffects;      // 엘릭서 효과
+
+}

--- a/backend/src/main/java/com/finalteam/loacompass/service/CharacterService.java
+++ b/backend/src/main/java/com/finalteam/loacompass/service/CharacterService.java
@@ -3,8 +3,11 @@ package com.finalteam.loacompass.service;
 import com.finalteam.loacompass.client.LostArkClient;
 import com.finalteam.loacompass.dto.CharacterProfileDto;
 import com.finalteam.loacompass.dto.CharacterSummaryDto;
+import com.finalteam.loacompass.dto.EquipmentDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -14,9 +17,11 @@ public class CharacterService {
 
     public CharacterSummaryDto getCharacter(String nickname) {
         CharacterProfileDto profile = lostArkClient.getCharacterProfile(nickname);
+        List<EquipmentDto> equipmentList = lostArkClient.getCharacterEquipment(nickname);
 
         CharacterSummaryDto summary = new CharacterSummaryDto();
         summary.setProfile(profile);
+        summary.setEquipments(equipmentList);
 
 
         return summary;

--- a/backend/src/main/java/com/finalteam/loacompass/service/CharacterService.java
+++ b/backend/src/main/java/com/finalteam/loacompass/service/CharacterService.java
@@ -2,15 +2,23 @@ package com.finalteam.loacompass.service;
 
 import com.finalteam.loacompass.client.LostArkClient;
 import com.finalteam.loacompass.dto.CharacterProfileDto;
+import com.finalteam.loacompass.dto.CharacterSummaryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class CharacterService {
+
     private final LostArkClient lostArkClient;
 
-    public CharacterProfileDto getCharacter(String nickname) {
-        return lostArkClient.getCharacterProfile(nickname);
+    public CharacterSummaryDto getCharacter(String nickname) {
+        CharacterProfileDto profile = lostArkClient.getCharacterProfile(nickname);
+
+        CharacterSummaryDto summary = new CharacterSummaryDto();
+        summary.setProfile(profile);
+
+
+        return summary;
     }
 }

--- a/backend/src/main/java/com/finalteam/loacompass/service/CharacterService.java
+++ b/backend/src/main/java/com/finalteam/loacompass/service/CharacterService.java
@@ -19,11 +19,19 @@ public class CharacterService {
         CharacterProfileDto profile = lostArkClient.getCharacterProfile(nickname);
         List<EquipmentDto> equipmentList = lostArkClient.getCharacterEquipment(nickname);
 
+        int totalTranscendence = 0;
+        for (EquipmentDto dto : equipmentList) {
+            if (dto.getTranscendencePoint() != null) {
+                totalTranscendence += dto.getTranscendencePoint();
+            }
+        }
+
         CharacterSummaryDto summary = new CharacterSummaryDto();
         summary.setProfile(profile);
         summary.setEquipments(equipmentList);
-
+        summary.setTranscendenceTotal(totalTranscendence); // ← 여기에 설정
 
         return summary;
     }
+
 }

--- a/backend/src/main/java/com/finalteam/loacompass/util/TooltipParser.java
+++ b/backend/src/main/java/com/finalteam/loacompass/util/TooltipParser.java
@@ -24,34 +24,65 @@ public class TooltipParser {
 
             // 강화 단계
             JsonNode refinementNode = tooltipJson.path("Element_005").path("value");
+
             if (refinementNode.isTextual()) {
-                Matcher matcher = Pattern.compile("(\\d+)단계").matcher(refinementNode.asText());
+                String cleaned = refinementNode.asText().replaceAll("<.*?>", ""); // HTML 태그 제거
+                Matcher matcher = Pattern.compile("(\\d+)단계").matcher(cleaned);
                 if (matcher.find()) {
                     dto.setRefinementLevel(Integer.parseInt(matcher.group(1)));
                 }
             }
 
-            // 초월 단계
-            JsonNode transcendenceNode = tooltipJson.path("Element_009").path("value")
+            // 초월 단계 및 포인트
+            JsonNode transcendenceTopStr = tooltipJson.path("Element_009").path("value")
                     .path("Element_000").path("topStr");
-            if (transcendenceNode.isTextual()) {
-                Matcher matcher = Pattern.compile("초월.*?(\\d+)").matcher(transcendenceNode.asText());
+
+            if (transcendenceTopStr.isTextual()) {
+                String topStr = transcendenceTopStr.asText();
+
+                // 초월 단계 추출 (예: 7단계)
+                Matcher levelMatcher = Pattern.compile("초월.*?(\\d+)단계").matcher(topStr);
+                if (levelMatcher.find()) {
+                    dto.setTranscendenceLevel(Integer.parseInt(levelMatcher.group(1)));
+                }
+
+                // 장비별 초월 포인트 추출 (예: >21)
+                Matcher pointMatcher = Pattern.compile("img[^>]*>(\\d+)").matcher(topStr);
+                if (pointMatcher.find()) {
+                    dto.setTranscendencePoint(Integer.parseInt(pointMatcher.group(1)));
+                }
+            }
+
+            JsonNode transcendenceTotalNode = tooltipJson.path("Element_009")
+                    .path("value").path("Element_000").path("contentStr")
+                    .path("Element_001").path("contentStr");
+
+            if (transcendenceTotalNode.isTextual()) {
+                Matcher matcher = Pattern.compile("총.*?>(\\d+)개").matcher(transcendenceTotalNode.asText());
                 if (matcher.find()) {
-                    dto.setTranscendenceLevel(Integer.parseInt(matcher.group(1)));
                 }
             }
 
             // 엘릭서 이름
-            JsonNode elixirRoot = tooltipJson.path("Element_010").path("value");
-            if (elixirRoot != null && elixirRoot.has("Element_000")) {
-                JsonNode topStrNode = elixirRoot.path("Element_000").path("topStr");
-                if (topStrNode.isTextual()) {
-                    String topStr = topStrNode.asText().replaceAll("<.*?>", "");
-                    Matcher matcher = Pattern.compile("엘릭서\\s*(.*)").matcher(topStr);
-                    if (matcher.find()) {
-                        dto.setElixirName(matcher.group(1).trim());
+            List<String> elixirOptions = new ArrayList<>();
+
+            JsonNode contentGroup = tooltipJson.path("Element_010").path("value")
+                    .path("Element_000").path("contentStr");
+
+            if (contentGroup != null && contentGroup.isObject()) {
+                contentGroup.fields().forEachRemaining(entry -> {
+                    JsonNode content = entry.getValue().path("contentStr");
+                    if (content.isTextual()) {
+                        String text = content.asText().replaceAll("<.*?>", "").trim(); // HTML 제거
+                        // 예: "[투구] 선각자 (질서) Lv.5 아군 공격력 강화 효과 +4%"
+                        String[] parts = text.split("Lv\\."); // "Lv." 기준으로 앞부분 추출
+                        if (parts.length > 0) {
+                            String effectName = parts[0].replaceAll("\\[.*?\\]", "").trim(); // [투구] 제거
+                            elixirOptions.add(effectName);
+                        }
                     }
-                }
+                });
+                dto.setElixirOptions(elixirOptions);
             }
 
             // 엘릭서 효과
@@ -67,6 +98,12 @@ public class TooltipParser {
                     }
                 });
                 dto.setElixirEffects(effects);
+            }
+
+            // 품질
+            JsonNode qualityNode = tooltipJson.path("Element_001").path("value").path("qualityValue");
+            if (qualityNode.isInt()) {
+                dto.setQuality(qualityNode.intValue());
             }
 
             //디버깅용.  콘솔 엄청 기니까 나중에 삭제 ㄱ

--- a/backend/src/main/java/com/finalteam/loacompass/util/TooltipParser.java
+++ b/backend/src/main/java/com/finalteam/loacompass/util/TooltipParser.java
@@ -1,0 +1,83 @@
+package com.finalteam.loacompass.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.finalteam.loacompass.dto.EquipmentDto;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TooltipParser {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static void populateEquipmentDetails(EquipmentDto dto) {
+        try {
+            String rawTooltip = dto.getTooltip();
+
+            JsonNode tooltipJson = objectMapper.readTree(rawTooltip);
+            if (tooltipJson.isTextual()) {
+                tooltipJson = objectMapper.readTree(tooltipJson.asText());
+            }
+
+            // 강화 단계
+            JsonNode refinementNode = tooltipJson.path("Element_005").path("value");
+            if (refinementNode.isTextual()) {
+                Matcher matcher = Pattern.compile("(\\d+)단계").matcher(refinementNode.asText());
+                if (matcher.find()) {
+                    dto.setRefinementLevel(Integer.parseInt(matcher.group(1)));
+                }
+            }
+
+            // 초월 단계
+            JsonNode transcendenceNode = tooltipJson.path("Element_009").path("value")
+                    .path("Element_000").path("topStr");
+            if (transcendenceNode.isTextual()) {
+                Matcher matcher = Pattern.compile("초월.*?(\\d+)").matcher(transcendenceNode.asText());
+                if (matcher.find()) {
+                    dto.setTranscendenceLevel(Integer.parseInt(matcher.group(1)));
+                }
+            }
+
+            // 엘릭서 이름
+            JsonNode elixirRoot = tooltipJson.path("Element_010").path("value");
+            if (elixirRoot != null && elixirRoot.has("Element_000")) {
+                JsonNode topStrNode = elixirRoot.path("Element_000").path("topStr");
+                if (topStrNode.isTextual()) {
+                    String topStr = topStrNode.asText().replaceAll("<.*?>", "");
+                    Matcher matcher = Pattern.compile("엘릭서\\s*(.*)").matcher(topStr);
+                    if (matcher.find()) {
+                        dto.setElixirName(matcher.group(1).trim());
+                    }
+                }
+            }
+
+            // 엘릭서 효과
+            JsonNode elixirEffectGroup = tooltipJson.path("Element_011").path("value")
+                    .path("Element_000").path("contentStr");
+            if (elixirEffectGroup != null && elixirEffectGroup.isObject()) {
+                List<String> effects = new ArrayList<>();
+                elixirEffectGroup.fields().forEachRemaining(entry -> {
+                    JsonNode content = entry.getValue().path("contentStr");
+                    if (content.isTextual()) {
+                        String cleaned = content.asText().replaceAll("<.*?>", "");
+                        effects.add(cleaned);
+                    }
+                });
+                dto.setElixirEffects(effects);
+            }
+
+            //디버깅용.  콘솔 엄청 기니까 나중에 삭제 ㄱ
+            System.out.println("강화단계: " + dto.getRefinementLevel());
+            System.out.println("초월단계: " + dto.getTranscendenceLevel());
+            System.out.println("엘릭서이름: " + dto.getElixirName());
+            System.out.println("엘릭서효과: " + dto.getElixirEffects());
+
+
+        } catch (Exception e) {
+            System.err.println("Tooltip parsing failed: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 캐릭터 장비, 장비 정보(엘릭서 초월 등) 불러오기


---

## 🔍 변경 목적

[http://localhost:8080/api/characters/크레센토훅]  << 이거 불러올때 캐릭터 기본정보+장비에 포함된 스펙 요소(강화 수치, 초월, 엘릭서, 품질, 아이템 등급)를 함께 받아오게 구현.  (기존에는 기본 정보만 불러왔음)

캐릭터 프로필은  CharacterProfileDto로,  장비 관련은 EquipmentDto에 받은 후     
종합한 내용은  CharacterSummaryDto에 같이 담았음.     

이후 CharacterSummaryDto를 프론트로 보내줘서 화면에 표시할 예정.

+  엘릭서 수치, 카드, 악세서리 옵션, 돌, 팔찌 옵션 등 다른 스펙요소 아직 미포함임.  계속 추가 예정

api 응답 화면:
![image](https://github.com/user-attachments/assets/cfa15536-dc69-4501-b937-79eda294e390)


---

## 🔧 Key Changes

**어떤 변경 사항이 있나요? (해당되는 항목 체크)**

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향 주지 않는 변경사항 (오타 수정, 들여쓰기 등)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 설정 수정

---

## 🧪 Test Method (스크린샷 포함 가능)

- 어떤 방식으로 테스트했는지 작성  
- [x] 콘솔 응답 확인
- [x] 실제 페이지 렌더링 확인
- [ ] 예외 케이스 테스트 포함



---

## ✅ PR Checklist

- [ ] `./gradlew spotlessApply` 혹은 포맷팅 수행
- [ ] `npx prettier -w '**/*.html' '**/*.js' '**/*.css'`
- [ ] 변경 사항에 대한 테스트를 완료했습니다

---

## 🙋‍♂️ 작업자 / 리뷰어

- 작업자: @your-name  
- 리뷰 요청: @reviewer1 @reviewer2
