### PR TITLE
서버 인구 통계 백앤드

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/backend/src/main/java/com/finalteam/loacompass/population/PopulationDto.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/PopulationDto.java
@@ -1,0 +1,10 @@
+package com.finalteam.loacompass.population;
+
+import lombok.Data;
+
+@Data
+public class PopulationDto {
+    private String server;
+    private int population;
+    private double change;
+}

--- a/backend/src/main/java/com/finalteam/loacompass/population/PopulationLoader.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/PopulationLoader.java
@@ -1,0 +1,30 @@
+package com.finalteam.loacompass.population;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class PopulationLoader {
+
+    public List<PopulationDto> loadFromSampleJson() {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            InputStream is = new ClassPathResource("sample/population_sample.json").getInputStream();
+
+            JsonNode root = objectMapper.readTree(is);
+            JsonNode krNode = root.get("KR");
+
+            PopulationDto[] result = objectMapper.treeToValue(krNode, PopulationDto[].class);
+            return Arrays.asList(result);
+
+        } catch (Exception e) {
+            throw new RuntimeException("예제 JSON 로딩 실패", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/finalteam/loacompass/population/PopulationLoader.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/PopulationLoader.java
@@ -2,6 +2,7 @@ package com.finalteam.loacompass.population;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.finalteam.loacompass.population.dto.PopulationDto;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 

--- a/backend/src/main/java/com/finalteam/loacompass/population/PopulationTestRunner.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/PopulationTestRunner.java
@@ -1,5 +1,7 @@
 package com.finalteam.loacompass.population;
 
+import com.finalteam.loacompass.population.dto.PopulationDto;
+import com.finalteam.loacompass.population.service.PopulationService;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
@@ -9,15 +11,21 @@ import java.util.List;
 public class PopulationTestRunner implements CommandLineRunner {
 
     private final PopulationLoader loader;
+    private final PopulationService service;
 
-    public PopulationTestRunner(PopulationLoader loader) {
+    public PopulationTestRunner(PopulationLoader loader, PopulationService service) {
         this.loader = loader;
+        this.service = service;
     }
 
     @Override
     public void run(String... args) {
         List<PopulationDto> list = loader.loadFromSampleJson();
+
         list.forEach(p -> System.out.printf("서버: %s, 인구: %d, 증감: %.2f%%\n",
                 p.getServer(), p.getPopulation(), p.getChange()));
+
+        service.savePopulationSnapshot(list);
+        System.out.println("✅ 인구 데이터 저장 완료");
     }
 }

--- a/backend/src/main/java/com/finalteam/loacompass/population/PopulationTestRunner.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/PopulationTestRunner.java
@@ -1,0 +1,23 @@
+package com.finalteam.loacompass.population;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class PopulationTestRunner implements CommandLineRunner {
+
+    private final PopulationLoader loader;
+
+    public PopulationTestRunner(PopulationLoader loader) {
+        this.loader = loader;
+    }
+
+    @Override
+    public void run(String... args) {
+        List<PopulationDto> list = loader.loadFromSampleJson();
+        list.forEach(p -> System.out.printf("서버: %s, 인구: %d, 증감: %.2f%%\n",
+                p.getServer(), p.getPopulation(), p.getChange()));
+    }
+}

--- a/backend/src/main/java/com/finalteam/loacompass/population/controller/PopulationController.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/controller/PopulationController.java
@@ -20,4 +20,14 @@ public class PopulationController {
     public List<PopulationLog> getLatestPopulation() {
         return populationService.getLatestPopulation();
     }
+
+    @GetMapping("/history")
+    public List<PopulationLog> getPopulationHistory(@RequestParam String server) {
+        return populationService.getPopulationHistory(server);
+    }
+
+    @GetMapping("/rank")
+    public List<PopulationLog> getServerRanking() {
+        return populationService.getServerRanking();
+    }
 }

--- a/backend/src/main/java/com/finalteam/loacompass/population/controller/PopulationController.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/controller/PopulationController.java
@@ -1,0 +1,23 @@
+package com.finalteam.loacompass.population.controller;
+
+import com.finalteam.loacompass.population.entity.PopulationLog;
+import com.finalteam.loacompass.population.service.PopulationService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/population")
+public class PopulationController {
+
+    private final PopulationService populationService;
+
+    public PopulationController(PopulationService populationService) {
+        this.populationService = populationService;
+    }
+
+    @GetMapping("/latest")
+    public List<PopulationLog> getLatestPopulation() {
+        return populationService.getLatestPopulation();
+    }
+}

--- a/backend/src/main/java/com/finalteam/loacompass/population/dto/PopulationDto.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/dto/PopulationDto.java
@@ -1,4 +1,4 @@
-package com.finalteam.loacompass.population;
+package com.finalteam.loacompass.population.dto;
 
 import lombok.Data;
 

--- a/backend/src/main/java/com/finalteam/loacompass/population/entity/PopulationLog.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/entity/PopulationLog.java
@@ -1,0 +1,27 @@
+package com.finalteam.loacompass.population.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PopulationLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String serverName;
+
+    private int population;
+
+    private double changeRate;
+
+    private LocalDateTime recordedAt;
+}

--- a/backend/src/main/java/com/finalteam/loacompass/population/repository/PopulationLogRepository.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/repository/PopulationLogRepository.java
@@ -1,0 +1,16 @@
+package com.finalteam.loacompass.population.repository;
+
+import com.finalteam.loacompass.population.entity.PopulationLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PopulationLogRepository extends JpaRepository<PopulationLog, Long> {
+
+    @Query("SELECT p FROM PopulationLog p WHERE p.recordedAt = (SELECT MAX(p2.recordedAt) FROM PopulationLog p2)")
+    List<PopulationLog> findLatestSnapshot();
+
+    List<PopulationLog> findAllByRecordedAt(LocalDateTime recordedAt);
+}

--- a/backend/src/main/java/com/finalteam/loacompass/population/repository/PopulationLogRepository.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/repository/PopulationLogRepository.java
@@ -13,4 +13,13 @@ public interface PopulationLogRepository extends JpaRepository<PopulationLog, Lo
     List<PopulationLog> findLatestSnapshot();
 
     List<PopulationLog> findAllByRecordedAt(LocalDateTime recordedAt);
+
+    List<PopulationLog> findAllByServerNameOrderByRecordedAtAsc(String serverName);
+
+    @Query("""
+  SELECT p FROM PopulationLog p
+  WHERE p.recordedAt = (SELECT MAX(p2.recordedAt) FROM PopulationLog p2)
+  ORDER BY p.population DESC
+""")
+    List<PopulationLog> findRankedSnapshot();
 }

--- a/backend/src/main/java/com/finalteam/loacompass/population/service/PopulationService.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/service/PopulationService.java
@@ -35,4 +35,13 @@ public class PopulationService {
     public List<PopulationLog> getLatestPopulation() {
         return repository.findLatestSnapshot();
     }
+
+    public List<PopulationLog> getPopulationHistory(String serverName) {
+        return repository.findAllByServerNameOrderByRecordedAtAsc(serverName);
+    }
+
+    public List<PopulationLog> getServerRanking() {
+        return repository.findRankedSnapshot();
+    }
+
     }

--- a/backend/src/main/java/com/finalteam/loacompass/population/service/PopulationService.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/service/PopulationService.java
@@ -1,0 +1,38 @@
+package com.finalteam.loacompass.population.service;
+
+import com.finalteam.loacompass.population.dto.PopulationDto;
+import com.finalteam.loacompass.population.entity.PopulationLog;
+import com.finalteam.loacompass.population.repository.PopulationLogRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class PopulationService {
+
+    private final PopulationLogRepository repository;
+
+    public PopulationService(PopulationLogRepository repository) {
+        this.repository = repository;
+    }
+
+    public void savePopulationSnapshot(List<PopulationDto> dtoList) {
+        LocalDateTime now = LocalDateTime.now();  // 한 번만 생성
+
+        for (PopulationDto dto : dtoList) {
+            PopulationLog log = PopulationLog.builder()
+                    .serverName(dto.getServer())
+                    .population(dto.getPopulation())
+                    .changeRate(dto.getChange())
+                    .recordedAt(now)  // 모두 동일한 시간
+                    .build();
+
+            repository.save(log);
+        }
+    }
+
+    public List<PopulationLog> getLatestPopulation() {
+        return repository.findLatestSnapshot();
+    }
+    }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -10,6 +10,14 @@ spring:
   profiles:
     active: local
 
+  jpa:
+    hibernate:
+      ddl-auto: update  # 또는 create, validate
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
 mybatis:
   mapper-locations: classpath:mapper/**/*.xml
   type-aliases-package: com.finalteam.loacompass.entity

--- a/backend/src/main/resources/sample/population_sample.json
+++ b/backend/src/main/resources/sample/population_sample.json
@@ -1,0 +1,24 @@
+{
+  "KR": [
+    {
+      "server": "루페온",
+      "population": 185273,
+      "change": 1.42
+    },
+    {
+      "server": "실리안",
+      "population": 152789,
+      "change": -0.73
+    },
+    {
+      "server": "카마인",
+      "population": 144920,
+      "change": 0.11
+    },
+    {
+      "server": "아브렐슈드",
+      "population": 139084,
+      "change": -1.24
+    }
+  ]
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 서버 통계 백앤드 작업


1.  jpa 설정 넣었습니다.  현재 우리 프로젝트는 mybatis랑 jpa 병행해서 사용할수있게 했습니다.

2. population 이라는 별도의 패키지 따로 만들어서 작업했습니다

3. 서버 인구수 실제 데이터를 가져와야하는데 
가져오려고했던 https://api.lostats.net/population/region 엔드포인트가 더 이상 작동하지 않아서
population_sample.json라는 예제 json을 기준으로 만들었습니다.
최종적으로는 실제 데이터 가져오는 식으로 수정할 예정(데이터 수집 코드를 짜야됨)

![image](https://github.com/user-attachments/assets/57fe3932-b400-497e-9ad0-21c46ee3a7cd)

밑에 사진은 지금 들어간 예제 데이터
![image](https://github.com/user-attachments/assets/1fa61045-b924-413a-b24f-981f17e22c63)

서버 돌리면 콘솔창에 이렇게 뜹니다 (PopulationTestRunner.java)  -> 개발시 테스트용
![image](https://github.com/user-attachments/assets/9e8ab7fd-73fa-47bc-88e2-5df64b6828e4)



추가한 기능api  ("/api/population")

1)전체 서버 최신 인구  ("/latest")    -> 현재 각 서버에 몇명의 유저가 있는지 표기
2) 특정 서버 히스토리 ("/history")   ex:  " /history?server=루페온 "   -> 서버 인원수 증감 % 그래프로 구현할 예정
3) 전체 서버 랭킹 ("/rank")  -> 인원수 기준으로 현재 로스트아크 게임내 서버 순위 
+@  나중에 필요한거 있으면 더 추가할 예정

이거 바탕으로 프론트만들고, 실제 실시간 데이터 뽑아와서   차트형식으로 만들고 구현할 예정입니다

![image](https://github.com/user-attachments/assets/5916e4db-f3a7-4ff2-ae41-8f785cc95fa9)

gpt한테 물어보니까 2가지 방법을 추천하는데 둘다 찾아볼예정

---


---


**어떤 변경 사항이 있나요? (해당되는 항목 체크)**

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향 주지 않는 변경사항 (오타 수정, 들여쓰기 등)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 설정 수정

---

## 🧪 Test Method (스크린샷 포함 가능)

- 어떤 방식으로 테스트했는지 작성  
- [x] 콘솔 응답 확인
- [x] 실제 페이지 렌더링 확인
- [x] 예외 케이스 테스트 포함

(필요 시 스크린샷 첨부)

---

## ✅ PR Checklist

- [ ] `./gradlew spotlessApply` 혹은 포맷팅 수행
- [ ] `npx prettier -w '**/*.html' '**/*.js' '**/*.css'`
- [x] 변경 사항에 대한 테스트를 완료했습니다

---

## 🙋‍♂️ 작업자 / 리뷰어

- 작업자: @your-name  
- 리뷰 요청: @reviewer1 @reviewer2
