### PR TITLE
app.py - marishop scraper로 분리+이벤트 크롤링 리팩토링

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,11 +3,13 @@ from flask_cors import CORS
 import asyncio
 from scraper.inven_search import fetch_page, get_total_pages, fetch_all_pages, fetch_all_contents, search_posts
 from scraper.mari_shop import crawl_mari_shop
+from scraper.event_scraper import crawl_event_list
 
 app = Flask(__name__)
 CORS(app)
 
 BASE_URL = 'https://www.inven.co.kr/board/lostark/5355/'
+
 
 @app.route('/api/search', methods=['GET'])
 def search_inven():
@@ -35,10 +37,20 @@ def search_inven():
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
+
 @app.route("/api/shop-mari", methods=["GET"])
 def shop_mari():
     data = crawl_mari_shop()
     return jsonify(data)
+
+
+@app.route("/api/events", methods=["GET"])
+def get_events():
+    try:
+        return jsonify(crawl_event_list())
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
 
 if __name__ == '__main__':
     app.run(port=5000, debug=True)

--- a/app.py
+++ b/app.py
@@ -2,17 +2,12 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 import asyncio
 from scraper.inven_search import fetch_page, get_total_pages, fetch_all_pages, fetch_all_contents, search_posts
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
+from scraper.mari_shop import crawl_mari_shop
 
 app = Flask(__name__)
 CORS(app)
 
 BASE_URL = 'https://www.inven.co.kr/board/lostark/5355/'
-
 
 @app.route('/api/search', methods=['GET'])
 def search_inven():
@@ -40,83 +35,10 @@ def search_inven():
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
-
 @app.route("/api/shop-mari", methods=["GET"])
 def shop_mari():
-    options = Options()
-    options.add_argument("--headless")
-    options.add_argument("--disable-gpu")
-    options.add_argument("--no-sandbox")
-
-    driver = webdriver.Chrome(options=options)
-    driver.get("https://lostark.game.onstove.com/Shop#mari")
-
-    data = {
-        "remainTime": "",
-        "items": []
-    }
-
-    try:
-        # 남은 시간 추출
-        WebDriverWait(driver, 10).until(
-            EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".flip-clock-active"))
-        )
-        time_digits = driver.find_elements(By.CSS_SELECTOR, ".flip-clock-active")
-        remain_time = ""
-        for i, digit in enumerate(time_digits):
-            remain_time += digit.get_attribute("data-digit")
-            if (i + 1) % 2 == 0 and i < len(time_digits) - 1:
-                remain_time += ":"
-        data["remainTime"] = remain_time
-
-        # 아이템 목록 추출
-        WebDriverWait(driver, 10).until(
-            EC.presence_of_element_located((By.CSS_SELECTOR, "ul.list-items > li"))
-        )
-        items = driver.find_elements(By.CSS_SELECTOR, "ul.list-items > li")
-        for el in items[:6]:
-            try:
-                title = el.find_element(By.CSS_SELECTOR, ".item-name").text
-                image = el.find_element(By.CSS_SELECTOR, ".thumbs img").get_attribute("src")
-
-                price = ""
-                original = ""
-                price_display = ""
-                currency = "crystal"
-
-                try:
-                    price = el.find_element(By.CSS_SELECTOR, ".area-amount > .amount").text
-                    try:
-                        original = el.find_element(By.CSS_SELECTOR, ".area-amount > .amount--through").text
-                        price_display = f"{price} {original}"
-                    except:
-                        original = ""
-                        price_display = price
-                except Exception as e:
-                    print(f"[{title}] 가격 정보 없음: {e}")
-                    price = ""
-                    original = ""
-                    price_display = ""
-
-                data["items"].append({
-                    "title": title,
-                    "image": image,
-                    "currency": currency,
-                    "price": price,
-                    "originalPrice": original,
-                    "priceDisplay": price_display
-                })
-
-            except Exception as e:
-                print("아이템 파싱 오류:", e)
-
-    except Exception as e:
-        print("크롤링 전체 실패:", e)
-    finally:
-        driver.quit()
-
+    data = crawl_mari_shop()
     return jsonify(data)
-
 
 if __name__ == '__main__':
     app.run(port=5000, debug=True)

--- a/backend/src/main/java/com/finalteam/loacompass/controller/EventController.java
+++ b/backend/src/main/java/com/finalteam/loacompass/controller/EventController.java
@@ -1,25 +1,25 @@
-package com.finalteam.loacompass.controller;
-
-import com.finalteam.loacompass.dto.EventDto;
-import com.finalteam.loacompass.service.EventService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
-
-@RestController
-@RequestMapping("/api/events")
-public class EventController {
-
-    @Autowired
-    private EventService eventService;
-
-    @GetMapping
-    public ResponseEntity<List<EventDto>> getEvents() {
-        return ResponseEntity.ok(eventService.getEvents());
-    }
-}
+//package com.finalteam.loacompass.controller;
+//
+//import com.finalteam.loacompass.dto.EventDto;
+//import com.finalteam.loacompass.service.EventService;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.CrossOrigin;
+//import org.springframework.web.bind.annotation.GetMapping;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//import java.util.List;
+//
+//@RestController
+//@RequestMapping("/api/events")
+//public class EventController {
+//
+//    @Autowired
+//    private EventService eventService;
+//
+//    @GetMapping
+//    public ResponseEntity<List<EventDto>> getEvents() {
+//        return ResponseEntity.ok(eventService.getEvents());
+//    }
+//}

--- a/backend/src/main/java/com/finalteam/loacompass/crawling/client/FlaskEventClient.java
+++ b/backend/src/main/java/com/finalteam/loacompass/crawling/client/FlaskEventClient.java
@@ -1,0 +1,27 @@
+package com.finalteam.loacompass.crawling.client;
+
+import com.finalteam.loacompass.crawling.dto.EventDto;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpMethod;
+
+import java.util.List;
+
+@Component
+public class FlaskEventClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private static final String FLASK_EVENT_URL = "http://localhost:5000/api/events";
+
+    public List<EventDto> fetchEvents() {
+        ResponseEntity<List<EventDto>> response = restTemplate.exchange(
+                FLASK_EVENT_URL,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<List<EventDto>>() {}
+        );
+        return response.getBody();
+    }
+}

--- a/backend/src/main/java/com/finalteam/loacompass/crawling/controller/EventController.java
+++ b/backend/src/main/java/com/finalteam/loacompass/crawling/controller/EventController.java
@@ -1,0 +1,29 @@
+package com.finalteam.loacompass.crawling.controller;
+
+import com.finalteam.loacompass.crawling.client.FlaskEventClient;
+import com.finalteam.loacompass.crawling.dto.EventDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/events")
+public class EventController {
+
+    private final FlaskEventClient flaskEventClient;
+
+    @Autowired
+    public EventController(FlaskEventClient flaskEventClient) {
+        this.flaskEventClient = flaskEventClient;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<EventDto>> getEvents() {
+        return ResponseEntity.ok(flaskEventClient.fetchEvents());
+    }
+}
+

--- a/backend/src/main/java/com/finalteam/loacompass/crawling/dto/EventDto.java
+++ b/backend/src/main/java/com/finalteam/loacompass/crawling/dto/EventDto.java
@@ -1,0 +1,16 @@
+package com.finalteam.loacompass.crawling.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventDto {
+    private String id;
+    private String title;
+    private String imageUrl;
+    private String period;
+    private String url;
+}

--- a/backend/src/main/java/com/finalteam/loacompass/dto/EventDto.java
+++ b/backend/src/main/java/com/finalteam/loacompass/dto/EventDto.java
@@ -1,16 +1,16 @@
-package com.finalteam.loacompass.dto;
-
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class EventDto {
-    private String id;
-    private String title;
-    private String imageUrl;
-    private String period;
-    private String url;
-} 
+//package com.finalteam.loacompass.dto;
+//
+//import lombok.AllArgsConstructor;
+//import lombok.Data;
+//import lombok.NoArgsConstructor;
+//
+//@Data
+//@NoArgsConstructor
+//@AllArgsConstructor
+//public class EventDto {
+//    private String id;
+//    private String title;
+//    private String imageUrl;
+//    private String period;
+//    private String url;
+//}

--- a/backend/src/main/java/com/finalteam/loacompass/service/EventService.java
+++ b/backend/src/main/java/com/finalteam/loacompass/service/EventService.java
@@ -1,121 +1,121 @@
-package com.finalteam.loacompass.service;
-
-import com.finalteam.loacompass.dto.EventDto;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
-import org.springframework.stereotype.Service;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
-@Service
-public class EventService {
-
-    private static final String LOSTARK_EVENT_URL = "https://lostark.game.onstove.com/News/Event/Now";
-
-    public List<EventDto> getEvents() {
-        List<EventDto> events = new ArrayList<>();
-
-        try {
-            Document doc = Jsoup.connect(LOSTARK_EVENT_URL).get();
-            Elements eventElements = doc.select("div.list.list--event ul li");
-
-            for (Element event : eventElements) {
-                EventDto eventDto = new EventDto();
-
-                // 고유 ID 생성
-                eventDto.setId(UUID.randomUUID().toString());
-
-                // 이벤트 제목
-                Element title = event.selectFirst("span.list__title");
-                if (title != null) {
-                    eventDto.setTitle(title.text());
-                }
-
-                // 이벤트 기간
-                Element period = event.selectFirst("span.list__schedule");
-                if (period != null) {
-                    eventDto.setPeriod(period.text().replace("이벤트 기간 : ", "").trim());
-                }
-
-                // 이벤트 이미지
-                Element img = event.selectFirst("img");
-                if (img != null) {
-                    eventDto.setImageUrl(img.attr("src"));
-                }
-
-                // 이벤트 상세 URL
-                Element link = event.selectFirst("a");
-                if (link != null) {
-                    String href = link.attr("href");
-                    if (!href.startsWith("http")) {
-                        href = "https://lostark.game.onstove.com" + href;
-                    }
-                    eventDto.setUrl(href);
-                }
-
-                events.add(eventDto);
-            }
-        } catch (IOException e) {
-            // 실제 운영에서는 로깅 처리
-            System.err.println("이벤트 정보를 가져오는 중 오류 발생: " + e.getMessage());
-            // 오류 발생 시 기본 데이터 반환
-            return getDefaultEvents();
-        }
-
-        return events.isEmpty() ? getDefaultEvents() : events;
-    }
-
-    // 기본 이벤트 데이터 (API 오류 시 반환용)
-    private List<EventDto> getDefaultEvents() {
-        List<EventDto> defaultEvents = new ArrayList<>();
-
-        defaultEvents.add(new EventDto(
-                "1",
-                "환영의 힘을 모아라",
-                "https://cdn-lostark.game.onstove.com/uploadfiles/banner/b2e6ce9ed8d542c784ea99ee01be3c7f.jpg",
-                "2025.04.09 06:00 - 05.07 06:00",
-                "https://lostark.game.onstove.com/News/Event/Views/2149"));
-
-        defaultEvents.add(new EventDto(
-                "2",
-                "2025 아트 공모전 본선 투표",
-                "https://cdn-lostark.game.onstove.com/uploadfiles/banner/e5e8ec85f6084fea8d32d5dea5c1d064.jpg",
-                "2025.05.07 06:00 - 05.14 06:00",
-                "https://lostark.game.onstove.com/News/Event/Views/2150"));
-
-        defaultEvents.add(new EventDto(
-                "3",
-                "반짝반짝 교환소",
-                "https://cdn-lostark.game.onstove.com/uploadfiles/banner/ff04ec5b9f3d4784b7a7d166a70af6c9.jpg",
-                "2025.04.30 21:00 - 05.28 06:00",
-                "https://lostark.game.onstove.com/News/Event/Views/2148"));
-
-        defaultEvents.add(new EventDto(
-                "4",
-                "봄이 왔냥, PC방 PARTY TIME",
-                "https://cdn-lostark.game.onstove.com/uploadfiles/banner/7e694a53e0f94e62b2ef0a1ba70eeb08.jpg",
-                "2025.03.12 06:00 - 05.21 06:00",
-                "https://lostark.game.onstove.com/News/Event/Views/2145"));
-
-        defaultEvents.add(new EventDto(
-                "5",
-                "피크닉 도시락 만들기",
-                "https://cdn-lostark.game.onstove.com/uploadfiles/banner/7c76a4d3600844cebe5e50b97d97dd29.jpg",
-                "2025.05.07 06:00 - 06.04 06:00",
-                "https://lostark.game.onstove.com/News/Event/Views/2151"));
-
-        defaultEvents.add(new EventDto(
-                "6",
-                "강습 : 림레이크",
-                "https://cdn-lostark.game.onstove.com/uploadfiles/banner/8b344e1f69a74c9d80d87680ec334402.jpg",
-                "2025.03.26 06:00 - 06.18 06:00",
-                "https://lostark.game.onstove.com/News/Event/Views/2147"));
-
-        return defaultEvents;
-    }
-}
+//package com.finalteam.loacompass.service;
+//
+//import com.finalteam.loacompass.dto.EventDto;
+//import org.jsoup.Jsoup;
+//import org.jsoup.nodes.Document;
+//import org.jsoup.nodes.Element;
+//import org.jsoup.select.Elements;
+//import org.springframework.stereotype.Service;
+//
+//import java.io.IOException;
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.UUID;
+//
+//@Service
+//public class EventService {
+//
+//    private static final String LOSTARK_EVENT_URL = "https://lostark.game.onstove.com/News/Event/Now";
+//
+//    public List<EventDto> getEvents() {
+//        List<EventDto> events = new ArrayList<>();
+//
+//        try {
+//            Document doc = Jsoup.connect(LOSTARK_EVENT_URL).get();
+//            Elements eventElements = doc.select("div.list.list--event ul li");
+//
+//            for (Element event : eventElements) {
+//                EventDto eventDto = new EventDto();
+//
+//                // 고유 ID 생성
+//                eventDto.setId(UUID.randomUUID().toString());
+//
+//                // 이벤트 제목
+//                Element title = event.selectFirst("span.list__title");
+//                if (title != null) {
+//                    eventDto.setTitle(title.text());
+//                }
+//
+//                // 이벤트 기간
+//                Element period = event.selectFirst("span.list__schedule");
+//                if (period != null) {
+//                    eventDto.setPeriod(period.text().replace("이벤트 기간 : ", "").trim());
+//                }
+//
+//                // 이벤트 이미지
+//                Element img = event.selectFirst("img");
+//                if (img != null) {
+//                    eventDto.setImageUrl(img.attr("src"));
+//                }
+//
+//                // 이벤트 상세 URL
+//                Element link = event.selectFirst("a");
+//                if (link != null) {
+//                    String href = link.attr("href");
+//                    if (!href.startsWith("http")) {
+//                        href = "https://lostark.game.onstove.com" + href;
+//                    }
+//                    eventDto.setUrl(href);
+//                }
+//
+//                events.add(eventDto);
+//            }
+//        } catch (IOException e) {
+//            // 실제 운영에서는 로깅 처리
+//            System.err.println("이벤트 정보를 가져오는 중 오류 발생: " + e.getMessage());
+//            // 오류 발생 시 기본 데이터 반환
+//            return getDefaultEvents();
+//        }
+//
+//        return events.isEmpty() ? getDefaultEvents() : events;
+//    }
+//
+//    // 기본 이벤트 데이터 (API 오류 시 반환용)
+//    private List<EventDto> getDefaultEvents() {
+//        List<EventDto> defaultEvents = new ArrayList<>();
+//
+//        defaultEvents.add(new EventDto(
+//                "1",
+//                "환영의 힘을 모아라",
+//                "https://cdn-lostark.game.onstove.com/uploadfiles/banner/b2e6ce9ed8d542c784ea99ee01be3c7f.jpg",
+//                "2025.04.09 06:00 - 05.07 06:00",
+//                "https://lostark.game.onstove.com/News/Event/Views/2149"));
+//
+//        defaultEvents.add(new EventDto(
+//                "2",
+//                "2025 아트 공모전 본선 투표",
+//                "https://cdn-lostark.game.onstove.com/uploadfiles/banner/e5e8ec85f6084fea8d32d5dea5c1d064.jpg",
+//                "2025.05.07 06:00 - 05.14 06:00",
+//                "https://lostark.game.onstove.com/News/Event/Views/2150"));
+//
+//        defaultEvents.add(new EventDto(
+//                "3",
+//                "반짝반짝 교환소",
+//                "https://cdn-lostark.game.onstove.com/uploadfiles/banner/ff04ec5b9f3d4784b7a7d166a70af6c9.jpg",
+//                "2025.04.30 21:00 - 05.28 06:00",
+//                "https://lostark.game.onstove.com/News/Event/Views/2148"));
+//
+//        defaultEvents.add(new EventDto(
+//                "4",
+//                "봄이 왔냥, PC방 PARTY TIME",
+//                "https://cdn-lostark.game.onstove.com/uploadfiles/banner/7e694a53e0f94e62b2ef0a1ba70eeb08.jpg",
+//                "2025.03.12 06:00 - 05.21 06:00",
+//                "https://lostark.game.onstove.com/News/Event/Views/2145"));
+//
+//        defaultEvents.add(new EventDto(
+//                "5",
+//                "피크닉 도시락 만들기",
+//                "https://cdn-lostark.game.onstove.com/uploadfiles/banner/7c76a4d3600844cebe5e50b97d97dd29.jpg",
+//                "2025.05.07 06:00 - 06.04 06:00",
+//                "https://lostark.game.onstove.com/News/Event/Views/2151"));
+//
+//        defaultEvents.add(new EventDto(
+//                "6",
+//                "강습 : 림레이크",
+//                "https://cdn-lostark.game.onstove.com/uploadfiles/banner/8b344e1f69a74c9d80d87680ec334402.jpg",
+//                "2025.03.26 06:00 - 06.18 06:00",
+//                "https://lostark.game.onstove.com/News/Event/Views/2147"));
+//
+//        return defaultEvents;
+//    }
+//}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -38,7 +38,7 @@ function Home() {
         const fetchEvents = async () => {
             try {
                 setLoading(true);
-                const response = await axios.get('http://localhost:8080/api/events');
+                const response = await axios.get('api/events');
                 setEvents(response.data);
                 setError(null);
             } catch (err) {

--- a/scraper/event_scraper.py
+++ b/scraper/event_scraper.py
@@ -1,0 +1,54 @@
+import requests
+from bs4 import BeautifulSoup
+import uuid
+
+def crawl_event_list():
+    url = "https://lostark.game.onstove.com/News/Event/Now"
+    headers = {'User-Agent': 'Mozilla/5.0'}
+
+    try:
+        resp = requests.get(url, headers=headers)
+        soup = BeautifulSoup(resp.text, 'html.parser')
+
+        event_elements = soup.select("div.list.list--event ul li")
+        events = []
+
+        for el in event_elements:
+            title = el.select_one("span.list__title")
+            period = el.select_one("span.list__schedule")
+            img = el.select_one("img")
+            link = el.select_one("a")
+
+            events.append({
+                "id": str(uuid.uuid4()),
+                "title": title.text.strip() if title else "",
+                "period": period.text.replace("이벤트 기간 : ", "").strip() if period else "",
+                "imageUrl": img["src"] if img else "",
+                "url": f"https://lostark.game.onstove.com{link['href']}" if link else ""
+            })
+
+        return events
+
+    except Exception as e:
+        print("이벤트 크롤링 오류:", e)
+        return get_default_events()
+
+
+def get_default_events():
+    return [
+        {
+            "id": "1",
+            "title": "환영의 힘을 모아라",
+            "imageUrl": "https://cdn-lostark.game.onstove.com/uploadfiles/banner/b2e6ce9ed8d542c784ea99ee01be3c7f.jpg",
+            "period": "2025.04.09 06:00 - 05.07 06:00",
+            "url": "https://lostark.game.onstove.com/News/Event/Views/2149"
+        },
+        {
+            "id": "2",
+            "title": "2025 아트 공모전 본선 투표",
+            "imageUrl": "https://cdn-lostark.game.onstove.com/uploadfiles/banner/e5e8ec85f6084fea8d32d5dea5c1d064.jpg",
+            "period": "2025.05.07 06:00 - 05.14 06:00",
+            "url": "https://lostark.game.onstove.com/News/Event/Views/2150"
+        },
+        # 나머지도 필요하면 이어서 추가 가능
+    ]

--- a/scraper/mari_shop.py
+++ b/scraper/mari_shop.py
@@ -1,0 +1,78 @@
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+def crawl_mari_shop():
+    options = Options()
+    options.add_argument("--headless")
+    options.add_argument("--disable-gpu")
+    options.add_argument("--no-sandbox")
+
+    driver = webdriver.Chrome(options=options)
+    driver.get("https://lostark.game.onstove.com/Shop#mari")
+
+    data = {
+        "remainTime": "",
+        "items": []
+    }
+
+    try:
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_all_elements_located((By.CSS_SELECTOR, ".flip-clock-active"))
+        )
+        time_digits = driver.find_elements(By.CSS_SELECTOR, ".flip-clock-active")
+        remain_time = ""
+        for i, digit in enumerate(time_digits):
+            remain_time += digit.get_attribute("data-digit")
+            if (i + 1) % 2 == 0 and i < len(time_digits) - 1:
+                remain_time += ":"
+        data["remainTime"] = remain_time
+
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "ul.list-items > li"))
+        )
+        items = driver.find_elements(By.CSS_SELECTOR, "ul.list-items > li")
+        for el in items[:6]:
+            try:
+                title = el.find_element(By.CSS_SELECTOR, ".item-name").text
+                image = el.find_element(By.CSS_SELECTOR, ".thumbs img").get_attribute("src")
+
+                price = ""
+                original = ""
+                price_display = ""
+                currency = "crystal"
+
+                try:
+                    price = el.find_element(By.CSS_SELECTOR, ".area-amount > .amount").text
+                    try:
+                        original = el.find_element(By.CSS_SELECTOR, ".area-amount > .amount--through").text
+                        price_display = f"{price} {original}"
+                    except:
+                        original = ""
+                        price_display = price
+                except Exception as e:
+                    print(f"[{title}] 가격 정보 없음: {e}")
+                    price = ""
+                    original = ""
+                    price_display = ""
+
+                data["items"].append({
+                    "title": title,
+                    "image": image,
+                    "currency": currency,
+                    "price": price,
+                    "originalPrice": original,
+                    "priceDisplay": price_display
+                })
+
+            except Exception as e:
+                print("아이템 파싱 오류:", e)
+
+    except Exception as e:
+        print("크롤링 전체 실패:", e)
+    finally:
+        driver.quit()
+
+    return data


### PR DESCRIPTION
# 🚀 Pull Request

## 🧷 scraper 폴더 내에 마리샵 크롤링 로직 들어가게 분리

직전 버전까지  app.py에 마리샵 크롤링 로직이 들어가있었는데  사사게 크롤링처럼 scraper 폴더 내에 마리샵 로직들어가도록 분리함.

![image](https://github.com/user-attachments/assets/a6cdd4d6-eaaa-4a98-a767-e4ca5a78a164)

앞으로 추가할 크롤링 기능도(이벤트, 통계)

app.py 안에는 해당 라우터 연결 부분만 작성하고
로직은 scraper 폴더 안에 따로 넣어서 모아둘 예정


++

python app.py   <- 이거 서버 돌릴때  
aiohttp  ,  tqdm  ,  selenium 이런 모듈 설치안됐다고 뜰수있는데

그냥 그대로   pip install aiohttp , pip install selenium , pip install tqdm  이런식으로 pip install 붙여서 깔면 해결됨.

가끔 이미 깔았던 모듈인데 설치안됐다고 뜰때가 있긴함. 원인은 모르나 그때도 일단 다시 깔면 정상 작동함


++

마리샵이랑 똑같은 방식으로 scraper에 event_page.py  작성함.
crawling 패키지 안에 client, dto, service 작성.  
기존에 있던 EventController.java,  EventDto, EventService.java 는 주석처리했음
app.py에 이벤트 라우터 등록
프론트 (Home.jsx에  요청 주소 변경)

![image](https://github.com/user-attachments/assets/77416d79-4f3b-49a9-aa72-2d07b89bdda2)



---

## 🔧 Key Changes

**어떤 변경 사항이 있나요? (해당되는 항목 체크)**

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향 주지 않는 변경사항 (오타 수정, 들여쓰기 등)
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 설정 수정

---

## 🧪 Test Method (스크린샷 포함 가능)

- 어떤 방식으로 테스트했는지 작성  
- [ ] 콘솔 응답 확인
- [ ] 실제 페이지 렌더링 확인
- [ ] 예외 케이스 테스트 포함

(필요 시 스크린샷 첨부)

---

## ✅ PR Checklist

- [ ] `./gradlew spotlessApply` 혹은 포맷팅 수행
- [ ] `npx prettier -w '**/*.html' '**/*.js' '**/*.css'`
- [x] 변경 사항에 대한 테스트를 완료했습니다

---

## 🙋‍♂️ 작업자 / 리뷰어

- 작업자: @your-name  
- 리뷰 요청: @reviewer1 @reviewer2
