### PR TITLE
닉네임중복시 통계처리 수정

### DIFF
--- a/backend/src/main/java/com/finalteam/loacompass/population/entity/CharacterRecord.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/entity/CharacterRecord.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -17,6 +18,7 @@ public class CharacterRecord {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "character_name", nullable = false)
     private String characterName;
 
     private String serverName;
@@ -25,7 +27,8 @@ public class CharacterRecord {
 
     private float itemLevel;
 
-    private LocalDate recordedAt;  // 검색된 날짜
+    @Column(name = "recorded_at")
+    private LocalDateTime recordedAt;  // 검색된 날짜
 
 
 

--- a/backend/src/main/java/com/finalteam/loacompass/population/repository/CharacterRecordRepository.java
+++ b/backend/src/main/java/com/finalteam/loacompass/population/repository/CharacterRecordRepository.java
@@ -14,27 +14,50 @@ public interface CharacterRecordRepository extends JpaRepository<CharacterRecord
     // 오늘 기준
     boolean existsByCharacterNameAndRecordedAt(String characterName, LocalDate recordedAt);
 
-    @Query("SELECT r.serverName, COUNT(r) FROM CharacterRecord r WHERE r.recordedAt = :date GROUP BY r.serverName")
+    // 오늘 기준 - 중복 캐릭터 제거
+    @Query("""
+        SELECT r.serverName, COUNT(DISTINCT r.characterName)
+        FROM CharacterRecord r
+        WHERE r.recordedAt = :date
+        GROUP BY r.serverName
+    """)
     List<Object[]> getServerPopulation(@Param("date") LocalDate date);
 
-    @Query("SELECT r.serverName, r.characterClass, COUNT(r) FROM CharacterRecord r WHERE r.recordedAt = :date GROUP BY r.serverName, r.characterClass")
+    @Query("""
+        SELECT r.serverName, r.characterClass, COUNT(DISTINCT r.characterName)
+        FROM CharacterRecord r
+        WHERE r.recordedAt = :date
+        GROUP BY r.serverName, r.characterClass
+    """)
     List<Object[]> getServerClassDistribution(@Param("date") LocalDate date);
 
     Optional<CharacterRecord> findTopByRecordedAtOrderByItemLevelDesc(LocalDate date);
 
     List<CharacterRecord> findAllByRecordedAt(LocalDate recordedAt);
 
-    // 누적 기준 쿼리
-    @Query("SELECT r.serverName, COUNT(r) FROM CharacterRecord r GROUP BY r.serverName")
+    // 누적 기준 - 중복 캐릭터 제거
+    @Query("""
+        SELECT r.serverName, COUNT(DISTINCT r.characterName)
+        FROM CharacterRecord r
+        GROUP BY r.serverName
+    """)
     List<Object[]> getTotalServerPopulation();
 
-    @Query("SELECT r.serverName, r.characterClass, COUNT(r) FROM CharacterRecord r GROUP BY r.serverName, r.characterClass")
+    @Query("""
+        SELECT r.serverName, r.characterClass, COUNT(DISTINCT r.characterName)
+        FROM CharacterRecord r
+        GROUP BY r.serverName, r.characterClass
+    """)
     List<Object[]> getTotalServerClassDistribution();
 
     @Query("SELECT r FROM CharacterRecord r ORDER BY r.itemLevel DESC LIMIT 1")
     Optional<CharacterRecord> findTopByOrderByItemLevelDesc();
 
-    @Query("SELECT r.characterClass, COUNT(r) FROM CharacterRecord r GROUP BY r.characterClass")
+    @Query("""
+        SELECT r.characterClass, COUNT(DISTINCT r.characterName)
+        FROM CharacterRecord r
+        GROUP BY r.characterClass
+    """)
     List<Object[]> getTotalClassDistribution();
 
     @Query("""
@@ -43,7 +66,7 @@ public interface CharacterRecordRepository extends JpaRepository<CharacterRecord
             WHEN r.itemLevel < 1640 THEN '1640 미만' 
             WHEN r.itemLevel >= 1760 THEN '1760+' 
             ELSE CONCAT(CAST(FLOOR(r.itemLevel / 10) * 10 AS string), '-', CAST(FLOOR(r.itemLevel / 10) * 10 + 10 AS string)) 
-        END AS levelRange, COUNT(r) 
+        END AS levelRange, COUNT(DISTINCT r.characterName)
         FROM CharacterRecord r 
         GROUP BY 
         CASE 
@@ -53,4 +76,6 @@ public interface CharacterRecordRepository extends JpaRepository<CharacterRecord
         END
     """)
     List<Object[]> getTotalLevelRangeDistribution();
+
+    Optional<CharacterRecord> findByCharacterName(String characterName);
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 🧷 제목 (Title)

![image](https://github.com/user-attachments/assets/b459d41c-3a25-4219-a9a4-4052c1dbd701)
같은 닉네임을 검색했을때  검색날짜(recorded_at)가 다르면  db에 따로 저장됐는데(나중에 변화 추이 계산하기 위해 중복저장필요함)

통계 기능에서 이게 각각 다른사람 1명씩으로 계산해서 나왔음. 예를들면 지금 통계에 '기공사'라는 직업이 '드버트'라는 아이디 1명인데  DB에는 '드버트'가 4개 들어가있으니까    해당 직업이 4명으로 나옴

이부분  CharacterRecordRepository에서  처리해서 같은 닉네임은 1명으로 나오게 수정함

만약 특정 캐릭터의 정보(서버나 아이템)가 바뀌면  검색했을때 해당 바뀐 정보 반영해서 또 들어감(통계시에는 여전히 1명으로 처리)

---

## 🔍 변경 목적
<!-- 어떤 기능/이유 때문에 변경했는지 한 줄 설명 -->
ex) batch file을 추가하여 각 앱이 동시에 실행될 수 있도록 함

---

## 🔧 Key Changes

**어떤 변경 사항이 있나요? (해당되는 항목 체크)**

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향 주지 않는 변경사항 (오타 수정, 들여쓰기 등)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 설정 수정

---

## 🧪 Test Method (스크린샷 포함 가능)

- 어떤 방식으로 테스트했는지 작성  
- [x] 콘솔 응답 확인
- [ ] 실제 페이지 렌더링 확인
- [ ] 예외 케이스 테스트 포함

(필요 시 스크린샷 첨부)

---

## ✅ PR Checklist

- [ ] `./gradlew spotlessApply` 혹은 포맷팅 수행
- [ ] `npx prettier -w '**/*.html' '**/*.js' '**/*.css'`
- [ ] 변경 사항에 대한 테스트를 완료했습니다

---

## 🙋‍♂️ 작업자 / 리뷰어

- 작업자: @your-name  
- 리뷰 요청: @reviewer1 @reviewer2
