### PR TITLE
통계 서버 인구 예측 AI Prophet 모델 적용+통계 다크모드

### DIFF
--- a/analysis/config.py
+++ b/analysis/config.py
@@ -1,0 +1,12 @@
+import mysql.connector
+
+
+def get_connection():
+    return mysql.connector.connect(
+        host="localhost",
+        port=3306,
+        user="bit1234",              # Spring과 동일
+        password="1234",             # Spring과 동일
+        database="loacompass",       # Spring과 동일
+        charset="utf8mb4"
+    )

--- a/analysis/population_forecaster.py
+++ b/analysis/population_forecaster.py
@@ -1,0 +1,56 @@
+import pandas as pd
+from prophet import Prophet
+from analysis.config import get_connection
+
+def forecast_top_server_growth():
+    conn = get_connection()
+
+    query = """
+        SELECT server_name, DATE(recorded_at) AS ds, COUNT(DISTINCT character_name) AS y
+        FROM character_record
+        GROUP BY server_name, DATE(recorded_at)
+    """
+    df_all = pd.read_sql(query, conn)
+    conn.close()
+
+    df_all['ds'] = pd.to_datetime(df_all['ds'])
+
+    summary = []
+
+    for server in df_all['server_name'].unique():
+        df = df_all[df_all['server_name'] == server][['ds', 'y']]
+        if len(df) < 5:
+            continue  # 기록 수 부족
+
+        model = Prophet()
+        model.fit(df)
+        future = model.make_future_dataframe(periods=7)
+        forecast = model.predict(future)
+
+        y_last = df.iloc[-1]['y']
+        y_pred = forecast.iloc[-1]['yhat']
+        growth = y_pred - y_last
+
+        # 🔒 증가량이 1 이상인 경우만 포함
+        if growth >= 1:
+            summary.append({
+                'server': server,
+                'current': round(y_last),
+                'forecast': round(y_pred),
+                'increase': round(growth)
+            })
+
+    # 증가 수 기준 정렬
+    summary.sort(key=lambda x: x['increase'], reverse=True)
+    top3 = summary[:3]
+
+    # 결과 포맷
+    result = []
+    if top3:
+        result.append("📈 AI 예측 결과, 다음 주 인구가 가장 많이 증가할 것으로 예상되는 서버는:")
+        for idx, row in enumerate(top3, start=1):
+            result.append(f"{idx}. {row['server']} (+{row['increase']}명 예상)")
+    else:
+        result.append("⚠️ 예측할 수 있는 유의미한 인구 증가가 감지되지 않았습니다.")
+
+    return result

--- a/analysis/population_predictor.py
+++ b/analysis/population_predictor.py
@@ -1,0 +1,54 @@
+import pandas as pd
+from analysis.config import get_connection
+
+def generate_population_summary():
+    conn = get_connection()
+
+    #  1. 누적 기준 인구 분석
+    total_query = """
+        SELECT server_name, COUNT(DISTINCT character_name) AS total
+        FROM character_record
+        GROUP BY server_name
+    """
+    total_df = pd.read_sql(total_query, conn)
+
+    #  2. 날짜별 인구 분석 (전날 대비 증가율 보기용)
+    history_query = """
+        SELECT server_name, DATE(recorded_at) AS date, COUNT(DISTINCT character_name) AS count
+        FROM character_record
+        GROUP BY server_name, DATE(recorded_at)
+    """
+    history_df = pd.read_sql(history_query, conn)
+    conn.close()
+
+    history_df['date'] = pd.to_datetime(history_df['date'])
+
+    summary = []
+
+    # 누적 기준 인구 1위 서버 출력
+    top = total_df.sort_values(by="total", ascending=False).iloc[0]
+    summary.append(
+        f"🔥 {top['server_name']}은 현재 저장된 캐릭터 데이터 기준으로 가장 인구가 많은 서버입니다. (총 {top['total']}명)"
+    )
+
+    # 각 서버별 변화율 계산 (증가한 경우만 표시)
+    for server in history_df['server_name'].unique():
+        server_df = history_df[history_df['server_name'] == server].sort_values('date')
+        if len(server_df) < 2:
+            continue
+
+        before = server_df.iloc[-2]['count']
+        after = server_df.iloc[-1]['count']
+        if before == 0:
+            continue
+
+        rate = ((after - before) / before) * 100
+
+        if abs(rate) < 0.1:
+            summary.append(f"🧘 {server}는 인구 변화가 거의 없습니다. (±0.0%)")
+        elif rate > 0:
+            summary.append(f"📈 {server}는 전날보다 +{rate:.1f}% 증가했습니다. ({before}명 → {after}명)")
+
+        #  감소는 무시
+
+    return summary

--- a/analysis/population_predictor.py
+++ b/analysis/population_predictor.py
@@ -1,54 +1,92 @@
 import pandas as pd
+from prophet import Prophet
 from analysis.config import get_connection
+
 
 def generate_population_summary():
     conn = get_connection()
 
-    #  1. 누적 기준 인구 분석
-    total_query = """
-        SELECT server_name, COUNT(DISTINCT character_name) AS total
+    # 전체 데이터 로딩
+    query = """
+        SELECT server_name, DATE(recorded_at) AS date, character_name
         FROM character_record
-        GROUP BY server_name
     """
-    total_df = pd.read_sql(total_query, conn)
-
-    #  2. 날짜별 인구 분석 (전날 대비 증가율 보기용)
-    history_query = """
-        SELECT server_name, DATE(recorded_at) AS date, COUNT(DISTINCT character_name) AS count
-        FROM character_record
-        GROUP BY server_name, DATE(recorded_at)
-    """
-    history_df = pd.read_sql(history_query, conn)
+    df = pd.read_sql(query, conn)
     conn.close()
 
-    history_df['date'] = pd.to_datetime(history_df['date'])
-
+    df['date'] = pd.to_datetime(df['date'])
     summary = []
 
-    # 누적 기준 인구 1위 서버 출력
-    top = total_df.sort_values(by="total", ascending=False).iloc[0]
-    summary.append(
-        f"🔥 {top['server_name']}은 현재 저장된 캐릭터 데이터 기준으로 가장 인구가 많은 서버입니다. (총 {top['total']}명)"
-    )
+    # 1. 누적 기준 인구 1위 서버
+    cumulative_df = df.groupby("server_name")["character_name"].nunique().reset_index(name="count")
+    top = cumulative_df.sort_values(by="count", ascending=False).iloc[0]
+    summary.append(f"🔥 {top['server_name']}은 현재 저장된 캐릭터 데이터 기준으로 가장 인구가 많은 서버입니다. (총 {top['count']}명)")
 
-    # 각 서버별 변화율 계산 (증가한 경우만 표시)
-    for server in history_df['server_name'].unique():
-        server_df = history_df[history_df['server_name'] == server].sort_values('date')
+    # 2. 최근 2일간 증감률 분석
+    count_df = df.groupby(["server_name", "date"])["character_name"].nunique().reset_index(name="count")
+
+    for server in count_df["server_name"].unique():
+        server_df = count_df[count_df["server_name"] == server].sort_values("date")
         if len(server_df) < 2:
             continue
-
-        before = server_df.iloc[-2]['count']
-        after = server_df.iloc[-1]['count']
+        before = server_df.iloc[-2]["count"]
+        after = server_df.iloc[-1]["count"]
         if before == 0:
             continue
-
         rate = ((after - before) / before) * 100
 
         if abs(rate) < 0.1:
-            summary.append(f"🧘 {server}는 인구 변화가 거의 없습니다. (±0.0%)")
+            summary.append(f"🪘 {server}는 인구 변화가 거의 없습니다. (±0.0%)")
         elif rate > 0:
-            summary.append(f"📈 {server}는 전날보다 +{rate:.1f}% 증가했습니다. ({before}명 → {after}명)")
+            summary.append(f"📈 {server}는 전날보다 +{rate:.1f}% 증가했습니다. ({int(before)}명 → {int(after)}명)")
 
-        #  감소는 무시
+    return summary
+
+
+def generate_population_summary_short():
+    conn = get_connection()
+
+    # 전체 데이터 로딩
+    query = """
+        SELECT server_name, DATE(recorded_at) AS date, character_name
+        FROM character_record
+    """
+    df = pd.read_sql(query, conn)
+    conn.close()
+
+    summary = []
+
+    if df.empty:
+        return ["⚠️ 데이터가 부족해 요약할 수 없습니다."]
+
+    df['date'] = pd.to_datetime(df['date'], errors='coerce')
+    if df['date'].isnull().all():
+        return ["⚠️ 날짜 정보가 유효하지 않습니다."]
+
+    # ✅ 1. 누적 기준 인구 1위 서버
+    cumulative_df = df.groupby("server_name")["character_name"].nunique().reset_index(name="count")
+    top_total = cumulative_df.sort_values(by="count", ascending=False).iloc[0]
+    summary.append(f"🔥 {top_total['server_name']}은 현재 저장된 캐릭터 데이터 기준으로 가장 인구가 많은 서버입니다. (총 {top_total['count']}명)")
+
+    # ✅ 2. 증감률 비교
+    count_df = df.groupby(["server_name", "date"])["character_name"].nunique().reset_index(name="count")
+
+    rates = []
+    for server in count_df["server_name"].unique():
+        server_df = count_df[count_df["server_name"] == server].sort_values("date")
+        if len(server_df) < 2:
+            continue
+        before = server_df.iloc[-2]["count"]
+        after = server_df.iloc[-1]["count"]
+        if before == 0:
+            continue
+        rate = ((after - before) / before) * 100
+        rates.append((server, before, after, rate))
+
+    if rates:
+        top_growth = max(rates, key=lambda x: x[3])
+        summary.append(f"📈 {top_growth[0]}는 전날보다 +{top_growth[3]:.1f}% 증가했습니다. ({int(top_growth[1])}명 → {int(top_growth[2])}명)")
+        least_change = min(rates, key=lambda x: abs(x[3]))
+        summary.append(f"🪘 {least_change[0]}는 인구 변화가 거의 없습니다. (±{abs(least_change[3]):.1f}%)")
 
     return summary

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import asyncio
 from scraper.inven_search import fetch_page, get_total_pages, fetch_all_pages, fetch_all_contents, search_posts
 from scraper.mari_shop import crawl_mari_shop
 from scraper.event_scraper import crawl_event_list
+from analysis.population_predictor import generate_population_summary
 
 app = Flask(__name__)
 CORS(app)
@@ -51,6 +52,15 @@ def get_events():
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
+
+
+@app.route("/api/ai-summary", methods=["GET"])
+def get_ai_summary():
+    try:
+        summary = generate_population_summary()
+        return jsonify(summary)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
 
 if __name__ == '__main__':
     app.run(port=5000, debug=True)

--- a/app.py
+++ b/app.py
@@ -4,7 +4,11 @@ import asyncio
 from scraper.inven_search import fetch_page, get_total_pages, fetch_all_pages, fetch_all_contents, search_posts
 from scraper.mari_shop import crawl_mari_shop
 from scraper.event_scraper import crawl_event_list
-from analysis.population_predictor import generate_population_summary
+from analysis.population_predictor import (
+    generate_population_summary,
+    generate_population_summary_short
+)
+from analysis.population_forecaster import forecast_top_server_growth
 
 app = Flask(__name__)
 CORS(app)
@@ -56,9 +60,22 @@ def get_events():
 
 @app.route("/api/ai-summary", methods=["GET"])
 def get_ai_summary():
+    mode = request.args.get("mode", "full")
     try:
-        summary = generate_population_summary()
-        return jsonify(summary)
+        if mode == "short":
+            return jsonify(generate_population_summary_short())
+        else:
+            return jsonify(generate_population_summary())
+    except Exception as e:
+        import traceback
+        traceback.print_exc() 
+        return jsonify({"error": str(e)}), 500
+    
+@app.route("/api/forecast/top-growth", methods=["GET"])
+def get_top_growth_servers():
+    try:
+        summary_lines = forecast_top_server_growth()
+        return jsonify(summary_lines)
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 

--- a/frontend/src/components/statistics/AIAnalysisModal.jsx
+++ b/frontend/src/components/statistics/AIAnalysisModal.jsx
@@ -1,6 +1,8 @@
 export default function AIAnalysisModal({ visible, onClose, items = [], onDetailClick }) {
   if (!visible) return null;
 
+  const safeItems = Array.isArray(items) ? items : [];
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
       <div className="bg-white w-[90%] max-w-md rounded-lg shadow-lg">
@@ -12,10 +14,10 @@ export default function AIAnalysisModal({ visible, onClose, items = [], onDetail
 
         {/* 본문 */}
         <div className="p-4 space-y-2 text-sm text-gray-800">
-          {items.length === 0 ? (
+          {safeItems.length === 0 ? (
             <p className="text-gray-400">분석 데이터를 불러오는 중...</p>
           ) : (
-            items.map((item, idx) => (
+            safeItems.map((item, idx) => (
               <div key={idx} className="flex items-start gap-2">
                 <span>•</span>
                 <span>{item}</span>

--- a/frontend/src/components/statistics/ServerPopulationChart.jsx
+++ b/frontend/src/components/statistics/ServerPopulationChart.jsx
@@ -27,9 +27,9 @@ export default function ServerPopulationChart() {
   const total = data.reduce((sum, d) => sum + d.count, 0);
 
   return (
-    <div className="w-full h-[400px] mt-10">
+    <div className="w-full h-[400px] mt-10 bg-white dark:bg-gray-900 text-black dark:text-white p-4 rounded shadow">
       <div className="flex justify-between items-center mb-4">
-        <h2 className="text-xl font-bold">서버별 인원 비율</h2>
+        <h2 className="text-xl font-bold text-gray-800 dark:text-white">서버별 인원 비율</h2>
         <button
           className="bg-blue-500 text-white px-3 py-1 rounded text-sm hover:bg-blue-600"
           onClick={() => setViewMode(viewMode === 'bar' ? 'pie' : 'bar')}
@@ -41,16 +41,20 @@ export default function ServerPopulationChart() {
       <ResponsiveContainer width="100%" height="100%">
         {viewMode === 'bar' ? (
           <BarChart data={data} margin={{ top: 10, right: 30, left: 30, bottom: 10 }}>
-            <XAxis dataKey="serverName" />
-            <YAxis />
+            <XAxis dataKey="serverName" stroke="currentColor" />
+            <YAxis stroke="currentColor" />
             <Tooltip
               formatter={(value) => {
                 const percent = formatPercent(value, total);
                 return [`${value}명 (${percent})`, '인원'];
               }}
-              contentStyle={TOOLTIP_STYLE}
+              contentStyle={{
+                ...TOOLTIP_STYLE,
+                backgroundColor: "#1f2937", // dark:bg-gray-800
+                color: "#fff",
+              }}
             />
-            <Legend />
+            <Legend wrapperStyle={{ color: "currentColor" }} />
             <Bar dataKey="count" name="인원 수">
               {data.map((_, idx) => (
                 <Cell key={idx} fill={CHART_COLORS[idx % CHART_COLORS.length]} />
@@ -78,9 +82,13 @@ export default function ServerPopulationChart() {
                 const percent = formatPercent(value, total);
                 return [`${percent}`, '비율'];
               }}
-              contentStyle={TOOLTIP_STYLE}
+              contentStyle={{
+                ...TOOLTIP_STYLE,
+                backgroundColor: "#1f2937",
+                color: "#fff"
+              }}
             />
-            <Legend />
+            <Legend wrapperStyle={{ color: "currentColor" }} />
           </PieChart>
         )}
       </ResponsiveContainer>

--- a/frontend/src/components/statistics/StatisticsTabs.jsx
+++ b/frontend/src/components/statistics/StatisticsTabs.jsx
@@ -10,15 +10,30 @@ export default function StatisticsTabs({ title }) {
   const [activeTab, setActiveTab] = useState("player");
   const [showModal, setShowModal] = useState(false);
   const [showPanel, setShowPanel] = useState(false);
-  const [aiSummary, setAiSummary] = useState([]);
+  const [aiSummaryShort, setAiSummaryShort] = useState([]);
+  const [aiSummaryFull, setAiSummaryFull] = useState([]);
+  const [forecastSummary, setForecastSummary] = useState([]);
 
-  // Flask API에서 AI 요약 데이터 가져오기
+  // 1. AI 요약 데이터
   useEffect(() => {
+    fetch("http://localhost:5000/api/ai-summary?mode=short")
+      .then(res => res.json())
+      .then(setAiSummaryShort)
+      .catch(err => console.error("요약 불러오기 실패:", err));
+
     fetch("http://localhost:5000/api/ai-summary")
+      .then(res => res.json())
+      .then(setAiSummaryFull)
+      .catch(err => console.error("전체 불러오기 실패:", err));
+  }, []);
+
+  // 2. AI 예측 데이터
+  useEffect(() => {
+    fetch("http://localhost:5000/api/forecast/top-growth")
       .then((res) => res.json())
-      .then((data) => setAiSummary(data))
+      .then((data) => setForecastSummary(data))
       .catch((err) => {
-        console.error("AI 분석 요약 데이터를 불러오는 데 실패했습니다:", err);
+        console.error("AI 예측 데이터를 불러오는 데 실패했습니다:", err);
       });
   }, []);
 
@@ -28,6 +43,8 @@ export default function StatisticsTabs({ title }) {
     { id: "class", label: "직업별 분포" },
     { id: "level", label: "레벨별 분포" },
   ];
+
+  const combinedSummary = [...aiSummaryFull, "------------------------------", ...forecastSummary];
 
   return (
     <div className="w-full p-4">
@@ -68,7 +85,6 @@ export default function StatisticsTabs({ title }) {
         {activeTab === "level" && <TotalLevelChart />}
       </div>
 
-      {/* 중앙 팝업 모달 */}
       <AIAnalysisModal
         visible={showModal}
         onClose={() => setShowModal(false)}
@@ -76,14 +92,13 @@ export default function StatisticsTabs({ title }) {
           setShowModal(false);
           setShowPanel(true);
         }}
-        items={aiSummary}
+        items={aiSummaryShort}
       />
 
-      {/* 오른쪽 슬라이드 패널 */}
       <AISidePanel
         visible={showPanel}
         onClose={() => setShowPanel(false)}
-        items={aiSummary}
+        items={combinedSummary}
       />
     </div>
   );

--- a/frontend/src/components/statistics/StatisticsTabs.jsx
+++ b/frontend/src/components/statistics/StatisticsTabs.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import TopPlayerCard from "./TopPlayerCard";
 import ServerPopulationChart from "./ServerPopulationChart";
 import TotalClassChart from "./TotalClassChart";
@@ -10,12 +10,17 @@ export default function StatisticsTabs({ title }) {
   const [activeTab, setActiveTab] = useState("player");
   const [showModal, setShowModal] = useState(false);
   const [showPanel, setShowPanel] = useState(false);
+  const [aiSummary, setAiSummary] = useState([]);
 
-  const aiSummary = [
-    "🔥 인기 서버: 카마인",
-    "📈 성장 서버: 카제로스",
-    "🧘 조용한 서버: 니나브",
-  ];
+  // Flask API에서 AI 요약 데이터 가져오기
+  useEffect(() => {
+    fetch("http://localhost:5000/api/ai-summary")
+      .then((res) => res.json())
+      .then((data) => setAiSummary(data))
+      .catch((err) => {
+        console.error("AI 분석 요약 데이터를 불러오는 데 실패했습니다:", err);
+      });
+  }, []);
 
   const tabList = [
     { id: "player", label: "로침반 최고 점수" },

--- a/frontend/src/components/statistics/StatisticsTabs.jsx
+++ b/frontend/src/components/statistics/StatisticsTabs.jsx
@@ -47,10 +47,10 @@ export default function StatisticsTabs({ title }) {
   const combinedSummary = [...aiSummaryFull, "------------------------------", ...forecastSummary];
 
   return (
-    <div className="w-full p-4">
+    <div className="w-full p-4 bg-white dark:bg-gray-900 text-black dark:text-white min-h-screen">
       {/* 제목 + 버튼 한 줄에 표시 */}
       <div className="flex items-center space-x-4 mb-6">
-        <h2 className="text-2xl font-bold text-gray-800">{title}</h2>
+        <h2 className="text-2xl font-bold text-gray-800 dark:text-white">{title}</h2>
         <button
           onClick={() => setShowModal(true)}
           className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded shadow"
@@ -69,7 +69,7 @@ export default function StatisticsTabs({ title }) {
             className={`px-4 py-2 rounded-md font-medium border ${
               activeTab === tab.id
                 ? "bg-blue-600 text-white"
-                : "bg-white text-gray-700 border-gray-300"
+                : "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600"
             }`}
           >
             {tab.label}

--- a/frontend/src/components/statistics/TotalClassChart.jsx
+++ b/frontend/src/components/statistics/TotalClassChart.jsx
@@ -8,7 +8,7 @@ import {
   LABEL_STYLE,
   TOOLTIP_STYLE,
   formatPercent
-} from '../../styles/chartStyles'; // ✅ 상대경로
+} from '../../styles/chartStyles';
 
 export default function TotalClassChart() {
   const [data, setData] = useState([]);
@@ -26,9 +26,9 @@ export default function TotalClassChart() {
   const total = data.reduce((sum, d) => sum + d.count, 0);
 
   return (
-    <div className="w-full h-[500px] mt-8">
+    <div className="w-full h-[500px] mt-8 bg-white dark:bg-gray-900 text-black dark:text-white p-4 rounded shadow">
       <div className="flex justify-between items-center mb-4">
-        <h2 className="text-xl font-bold">전체 직업 분포</h2>
+        <h2 className="text-xl font-bold text-gray-800 dark:text-white">전체 직업 분포</h2>
         <button
           className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"
           onClick={() => setViewMode(viewMode === 'pie' ? 'bar' : 'pie')}
@@ -59,9 +59,13 @@ export default function TotalClassChart() {
                 const percent = formatPercent(value, total);
                 return [`${percent}`, '비율'];
               }}
-              contentStyle={TOOLTIP_STYLE}
+              contentStyle={{
+                ...TOOLTIP_STYLE,
+                backgroundColor: '#1f2937',
+                color: '#fff',
+              }}
             />
-            <Legend />
+            <Legend wrapperStyle={{ color: 'currentColor' }} />
           </PieChart>
         ) : (
           <BarChart
@@ -69,16 +73,20 @@ export default function TotalClassChart() {
             data={data}
             margin={{ top: 10, right: 30, bottom: 10, left: 120 }}
           >
-            <XAxis type="number" hide />
-            <YAxis type="category" dataKey="characterClass" />
+            <XAxis type="number" stroke="currentColor" />
+            <YAxis type="category" dataKey="characterClass" stroke="currentColor" />
             <Tooltip
               formatter={(value) => {
                 const percent = formatPercent(value, total);
                 return [`${value}명 (${percent})`, '인원'];
               }}
-              contentStyle={TOOLTIP_STYLE}
+              contentStyle={{
+                ...TOOLTIP_STYLE,
+                backgroundColor: '#1f2937',
+                color: '#fff',
+              }}
             />
-            <Legend />
+            <Legend wrapperStyle={{ color: 'currentColor' }} />
             <Bar dataKey="count" name="인원 수">
               <LabelList
                 dataKey="count"

--- a/frontend/src/components/statistics/TotalLevelChart.jsx
+++ b/frontend/src/components/statistics/TotalLevelChart.jsx
@@ -1,101 +1,109 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import {
-    BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer,
-    PieChart, Pie, Cell, LabelList
+  BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer,
+  PieChart, Pie, Cell, LabelList
 } from 'recharts';
 import {
-    CHART_COLORS,
-    LABEL_STYLE,
-    TOOLTIP_STYLE,
-    formatPercent
+  CHART_COLORS,
+  LABEL_STYLE,
+  TOOLTIP_STYLE,
+  formatPercent
 } from '../../styles/chartStyles';
 
 export default function TotalLevelChart() {
-    const [data, setData] = useState([]);
-    const [viewMode, setViewMode] = useState("bar");
-   
-    useEffect(() => {
-        axios.get('/api/statistics/total-level-distribution')
-            .then(res => {
-                const raw = res.data;
-                const sorted = [...raw].sort((a, b) => b.count - a.count); // 인원 수 기준 정렬
-                setData(sorted);
-            })
-            .catch(err => console.error(err));
-    }, []);
+  const [data, setData] = useState([]);
+  const [viewMode, setViewMode] = useState("bar");
 
-    const total = data.reduce((sum, d) => sum + d.count, 0);
+  useEffect(() => {
+    axios.get('/api/statistics/total-level-distribution')
+      .then(res => {
+        const raw = res.data;
+        const sorted = [...raw].sort((a, b) => b.count - a.count);
+        setData(sorted);
+      })
+      .catch(err => console.error(err));
+  }, []);
 
-    return (
-        <div className="w-full h-[500px] mt-8">
-            <div className="flex justify-between items-center mb-4">
-                <h2 className="text-xl font-bold">레벨 분포</h2>
-                <button
-                    onClick={() => setViewMode(viewMode === 'bar' ? 'pie' : 'bar')}
-                    className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"
-                >
-                    {viewMode === 'bar' ? 'Pie 보기' : 'Bar 보기'}
-                </button>
-            </div>
+  const total = data.reduce((sum, d) => sum + d.count, 0);
 
-            <ResponsiveContainer width="100%" height="100%">
-                {viewMode === 'bar' ? (
-                    <BarChart
-                        data={data}
-                        layout="vertical"
-                        barSize={36}
-                        margin={{ top: 10, right: 40, left: 100, bottom: 10 }}
-                    >
-                        <XAxis type="number" />
-                        <YAxis dataKey="levelRange" type="category" width={100} />
-                        <Tooltip
-                            formatter={(value) => {
-                                const percent = formatPercent(value, total);
-                                return [`${value}명 (${percent})`, '인원'];
-                            }}
-                            contentStyle={TOOLTIP_STYLE}
-                        />
-                        <Legend />
-                        <Bar dataKey="count" name="인원 수">
-                            <LabelList
-                                dataKey="count"
-                                position="right"
-                                content={({ value }) => `${value} (${formatPercent(value, total)})`}
-                                style={LABEL_STYLE}
-                            />
-                            {data.map((_, idx) => (
-                                <Cell key={idx} fill={CHART_COLORS[idx % CHART_COLORS.length]} />
-                            ))}
-                        </Bar>
-                    </BarChart>
-                ) : (
-                    <PieChart>
-                        <Pie
-                            data={data}
-                            dataKey="count"
-                            nameKey="levelRange"
-                            cx="50%"
-                            cy="50%"
-                            outerRadius={120}
-                            innerRadius={60}
-                            label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(1)}%`}
-                        >
-                            {data.map((entry, index) => (
-                                <Cell key={`cell-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
-                            ))}
-                        </Pie>
-                        <Tooltip
-                            formatter={(value) => {
-                                const percent = formatPercent(value, total);
-                                return [`${percent}`, '비율'];
-                            }}
-                            contentStyle={TOOLTIP_STYLE}
-                        />
-                        <Legend />
-                    </PieChart>
-                )}
-            </ResponsiveContainer>
-        </div>
-    );
+  return (
+    <div className="w-full h-[500px] mt-8 bg-white dark:bg-gray-900 text-black dark:text-white p-4 rounded shadow">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-xl font-bold text-gray-800 dark:text-white">레벨 분포</h2>
+        <button
+          onClick={() => setViewMode(viewMode === 'bar' ? 'pie' : 'bar')}
+          className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"
+        >
+          {viewMode === 'bar' ? 'Pie 보기' : 'Bar 보기'}
+        </button>
+      </div>
+
+      <ResponsiveContainer width="100%" height="100%">
+        {viewMode === 'bar' ? (
+          <BarChart
+            data={data}
+            layout="vertical"
+            barSize={36}
+            margin={{ top: 10, right: 40, left: 100, bottom: 10 }}
+          >
+            <XAxis type="number" stroke="currentColor" />
+            <YAxis dataKey="levelRange" type="category" width={100} stroke="currentColor" />
+            <Tooltip
+              formatter={(value) => {
+                const percent = formatPercent(value, total);
+                return [`${value}명 (${percent})`, '인원'];
+              }}
+              contentStyle={{
+                ...TOOLTIP_STYLE,
+                backgroundColor: '#1f2937',
+                color: '#fff',
+              }}
+            />
+            <Legend wrapperStyle={{ color: "currentColor" }} />
+            <Bar dataKey="count" name="인원 수">
+              <LabelList
+                dataKey="count"
+                position="right"
+                content={({ value }) => `${value} (${formatPercent(value, total)})`}
+                style={LABEL_STYLE}
+              />
+              {data.map((_, idx) => (
+                <Cell key={idx} fill={CHART_COLORS[idx % CHART_COLORS.length]} />
+              ))}
+            </Bar>
+          </BarChart>
+        ) : (
+          <PieChart>
+            <Pie
+              data={data}
+              dataKey="count"
+              nameKey="levelRange"
+              cx="50%"
+              cy="50%"
+              outerRadius={120}
+              innerRadius={60}
+              label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(1)}%`}
+            >
+              {data.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip
+              formatter={(value) => {
+                const percent = formatPercent(value, total);
+                return [`${percent}`, '비율'];
+              }}
+              contentStyle={{
+                ...TOOLTIP_STYLE,
+                backgroundColor: '#1f2937',
+                color: '#fff',
+              }}
+            />
+            <Legend wrapperStyle={{ color: "currentColor" }} />
+          </PieChart>
+        )}
+      </ResponsiveContainer>
+    </div>
+  );
 }

--- a/frontend/src/pages/Statistics.jsx
+++ b/frontend/src/pages/Statistics.jsx
@@ -3,7 +3,7 @@ import StatisticsTabs from "../components/statistics/StatisticsTabs";
 
 export default function Statistics() {
   return (
-    <div className="p-6">
+    <div className="p-6 bg-white dark:bg-gray-900 text-black dark:text-white min-h-screen">
       {/* 제목은 StatisticsTabs로 넘김 */}
       <StatisticsTabs title="로아 인구 통계" />
     </div>


### PR DESCRIPTION
# 🚀 Pull Request

## 🧷 통계에  '서버 인원 비율' 분석 모델

설치 해야될것들:
npm install lucide-react
pip install mysql-connector-python
pip install pandas
pip install pandas mysql-connector-python numpy
pip install prophet
pip install pandas matplotlib

---

Prophet 라는 시계열 데이터 예측 라이브러리 추가
[Proph](https://wikidocs.net/266272)

현재 DB에 저장된 character_record 테이블에서 서버부분을 뽑아서 분석함

근데 지금 표본 데이터수가 너무 적어서 예측이안되는중..

![image](https://github.com/user-attachments/assets/59641092-45b9-4cec-ba8b-4452b132a395)


![image](https://github.com/user-attachments/assets/e552db51-6af7-45de-a52a-c76d7ac66d03)

크롤링이랑 동일하게 plask 서버(로컬호스트5000)에서 돌아감
로직 코드 역시 analysis 폴더 내에 파이썬 코드들로 작성함


지금은 서버별 인원만 분석하고있는데

표본 데이터 더 모아보고

추가로 직업별 분석도 넣을 예정..
---
+ 

다크모드 적용
![image](https://github.com/user-attachments/assets/dc44057b-cca9-4fec-b1f8-2215bdf59da9)


## 🔧 Key Changes

**어떤 변경 사항이 있나요? (해당되는 항목 체크)**

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향 주지 않는 변경사항 (오타 수정, 들여쓰기 등)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 설정 수정

---

## 🧪 Test Method (스크린샷 포함 가능)

- 어떤 방식으로 테스트했는지 작성  
- [x] 콘솔 응답 확인
- [x] 실제 페이지 렌더링 확인
- [ ] 예외 케이스 테스트 포함

(필요 시 스크린샷 첨부)

---

## ✅ PR Checklist

- [ ] `./gradlew spotlessApply` 혹은 포맷팅 수행
- [ ] `npx prettier -w '**/*.html' '**/*.js' '**/*.css'`
- [ ] 변경 사항에 대한 테스트를 완료했습니다

---

## 🙋‍♂️ 작업자 / 리뷰어

- 작업자: @your-name  
- 리뷰 요청: @reviewer1 @reviewer2
